### PR TITLE
Fix missing check buttons for Weeks 9 & 10

### DIFF
--- a/index.html
+++ b/index.html
@@ -2223,6 +2223,8 @@ summary { font-weight: bold; }
 <label><input data-correct="true" name="q9_10" type="radio" value="Colour preference"/> Whether you personally like the wood colour more than other students do <button aria-label="Read answer Whether you personally like the wood color more than other students do" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></label>
 </li>
 </ol>
+<button class="check-btn" type="button">Check answers</button>
+<span class="quiz-msg" id="week9-quiz-msg"></span>
 </fieldset>
 </form>
 <h4>Conclusion</h4>
@@ -2333,6 +2335,8 @@ summary { font-weight: bold; }
 <label><input name="q10_10" type="radio" value="No real benefit"/> There’s no real benefit – it’s just busywork to fill time when projects are done <button aria-label="Read answer There’s no real benefit – it’s just busywork to fill time when projects are done" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></label>
 </li>
 </ol>
+<button class="check-btn" type="button">Check answers</button>
+<span class="quiz-msg" id="week10-quiz-msg"></span>
 </fieldset>
 </form>
 <h4>Conclusion</h4>


### PR DESCRIPTION
## Summary
- add the missing **Check answers** buttons and quiz result spans for the Week 9 and Week 10 quizzes

## Testing
- `git diff --stat`

------
https://chatgpt.com/codex/tasks/task_e_683f8a8429008326a546a37cfd3b749f